### PR TITLE
[Infrastructure UI] Fix HTTP request state management

### DIFF
--- a/x-pack/plugins/infra/public/hooks/use_http_request.tsx
+++ b/x-pack/plugins/infra/public/hooks/use_http_request.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { HttpHandler } from '@kbn/core/public';
 import { ToastInput } from '@kbn/core/public';
@@ -83,7 +83,7 @@ export function useHTTPRequest<Response>(
     };
   }, [abortable]);
 
-  const [request, makeRequest] = useTrackedPromise<any, Response>(
+  const [request, makeRequest, resetRequestState] = useTrackedPromise<any, Response>(
     {
       cancelPreviousOn: 'resolution',
       createPromise: () => {
@@ -117,17 +117,13 @@ export function useHTTPRequest<Response>(
     [pathname, body, method, fetch, toast, onError]
   );
 
-  const loading = useMemo(() => {
-    if (request.state === 'resolved' && response === null) {
-      return true;
-    }
-    return request.state === 'pending';
-  }, [request.state, response]);
+  const loading = request.state === 'uninitialized' || request.state === 'pending';
 
   return {
     response,
     error,
     loading,
     makeRequest,
+    resetRequestState,
   };
 }


### PR DESCRIPTION
## Summary

This PR fixes the state synchronization problem in the useHTTPRequest and useSnapshot hooks, which caused Hosts View components, particularly the tabs, to load their data 2 times when the submit button is hit.

On the first time, the state returned by those hooks would be an old state, from the previous request. That made the tabs render based on outdated information. At some point during the cycle `useHTTPRequest` receives the response, and it's propagated to the child components, this second time, the components would load using the correct and up-to-date information

